### PR TITLE
Bump jar version to 0.1.6 same as bal package

### DIFF
--- a/drive/Ballerina.toml
+++ b/drive/Ballerina.toml
@@ -12,7 +12,7 @@ license = ["Apache-2.0"]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.1.5.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.1.6.jar"
 groupId = "org.ballerinalang.googleapis.drive"
 artifactId = "java-wrapper"
-version = "0.1.5"
+version = "0.1.6"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.googleapis.drive
-version=0.1.5
+version=0.1.6
 ballerinaLangVersion=2.0.0-beta.3


### PR DESCRIPTION
# Description
Bump java component version to 0.1.6 same as ballerina package version mentioned in Ballerina.toml
 
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 