### PR TITLE
Set default placeholders for fileName, folderName, and docFileId

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -24,9 +24,9 @@ configurable string refreshToken = os:getEnv("REFRESH_TOKEN");
 // Access token support
 //configurable string accessToken = os:getEnv("ACCESS_TOKEN");
 
-configurable string fileName = ?;
-configurable string folderName = ?;
-configurable string docFileId = ?;
+configurable string fileName = "FILE_NAME";
+configurable string folderName = "FOLDER_NAME";
+configurable string docFileId = "DOCUMENT_FILE_ID";
 const string localFilePath = "./tests/resources/bar.jpeg";
 
 // Access token support


### PR DESCRIPTION
# Description

This PR sets default placeholder values for the three configurable variables (`fileName`, `folderName`, and `docFileId`) so that when no explicit value is provided, the application still has sensible defaults and avoids null/empty configuration errors. No additional dependencies are required for this change.

Fixes #162 

One line release note:

* Provide default placeholder values for `fileName`, `folderName`, and `docFileId`

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## How Has This Been Tested?

* No tests were added for this change.

**Test Configuration**:
- Ballerina Version: Swan Lake (latest)
- Operating System: windows
- Java SDK: JDK 17+

# Checklist

### Security checks

- [x] Followed secure coding standards in <http://wso2.com/technical-reports/wso2-secure-engineering-guidelines>?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
