### PR TITLE
Remove exportFile test function

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -26,7 +26,6 @@ configurable string refreshToken = os:getEnv("REFRESH_TOKEN");
 
 configurable string fileName = "FILE_NAME";
 configurable string folderName = "FOLDER_NAME";
-configurable string docFileId = "DOCUMENT_FILE_ID";
 const string localFilePath = "./tests/resources/bar.jpeg";
 
 // Access token support
@@ -453,17 +452,6 @@ function testUploadFileUsingByteArray() {
         log:printError(response.message());
         test:assertFail(response.message());
     }
-}
-
-@test:Config {
-    dependsOn: [testCreateFile]
-}
-function testExportFile() returns error? {
-    log:printInfo("Gdrive Client -> testExportFile()");
-    string mimeType = "text/markdown";
-    FileContent content = check driveClient->exportFile(docFileId, mimeType);
-    log:printInfo(content.toString().substring(0, 10));
-    test:assertNotEquals(content, EMPTY_STRING, msg = "Expect File content");
 }
 
 @test:Config {}

--- a/examples/list_changes.bal
+++ b/examples/list_changes.bal
@@ -49,7 +49,7 @@ public function main() returns error? {
             boolean foundChanges = false;
             changesResponse.forEach(function(drive:Change change) {
                 foundChanges = true;
-                log:printInfo(`Change detected for file ID: ${change.fileId}`);
+                log:printInfo("Change detected");
             });
             if !foundChanges {
                 log:printInfo("No changes found since token.");


### PR DESCRIPTION
# Description

This PR removes the `exportFile` test function, which is no longer necessary for the current module structure. This API will be covered by the revamping effort yet to be done, ensuring more comprehensive and streamlined test coverage in the future. This cleanup reduces maintenance effort without affecting existing functionality.

Fixes #163

One line release note:

* Remove `exportFile` test function

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Code cleanup (non-breaking change that removes unused code)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## How Has This Been Tested?

* The test function was removed without impacting the remaining test coverage.

**Test Configuration**:

* Ballerina Version: Swan Lake (latest)
* Operating System: Windows
* Java SDK: JDK 17+

# Checklist

### Security checks

* [x] Followed secure coding standards in [http://wso2.com/technical-reports/wso2-secure-engineering-guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?
* [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
