### PR TITLE
Use env variables in test credentials

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -15,11 +15,12 @@
 // under the License.
 
 import ballerina/log;
+import ballerina/os;
 import ballerina/test;
 
-configurable string clientId = ?;
-configurable string clientSecret = ?;
-configurable string refreshToken = ?;
+configurable string clientId = os:getEnv("CLIENT_ID");
+configurable string clientSecret = os:getEnv("CLIENT_SECRET");
+configurable string refreshToken = os:getEnv("REFRESH_TOKEN");
 
 // Test resource for upload tests
 const string LOCAL_FILE_PATH = "./tests/resources/bar.jpeg";


### PR DESCRIPTION
# Description

$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the test credentials configuration to use environment variables instead of placeholder values, improving the security and flexibility of the test setup.

## Changes

**File: `ballerina/tests/test.bal`**

- Added import for `ballerina/os` module
- Modified three configurable string variables to read from environment variables at runtime:
  - `clientId`: now reads from `CLIENT_ID` environment variable
  - `clientSecret`: now reads from `CLIENT_SECRET` environment variable  
  - `refreshToken`: now reads from `REFRESH_TOKEN` environment variable

This change enables the drive client authentication to source sensitive credentials from the runtime environment, eliminating the use of placeholder values in the test configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->